### PR TITLE
Improve rendered documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ doctest = false
 [profile.release]
 codegen-units = 1
 lto = true
+
+[package.metadata.docs.rs]
+# build docs for all features
+all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![no_std]
 
 mod dht;


### PR DESCRIPTION
- Add metadata so docs.rs calls cargo doc with `--all-features`
- Include `README.md` in the top-level crate documentation